### PR TITLE
fix: align API routes to /api/v1 across frontend and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,63 +225,63 @@ npm run type-check
 The API follows RESTful conventions with the following structure:
 
 ### Authentication
-- `POST /api/auth/register` - Register a new user
-- `POST /api/auth/login` - User login
+- `POST /api/v1/auth/register` - Register a new user
+- `POST /api/v1/auth/login` - User login
 
 ### Users (Admin access required for most endpoints)
-- `GET /api/users` - List all users
-- `GET /api/users/:id` - Get specific user
-- `PUT /api/users/:id` - Update user
-- `DELETE /api/users/:id` - Delete user
-- `GET /api/users/me` - Get current user profile
-- `PUT /api/users/me` - Update current user profile
+- `GET /api/v1/users` - List all users
+- `GET /api/v1/users/:id` - Get specific user
+- `PUT /api/v1/users/:id` - Update user
+- `DELETE /api/v1/users/:id` - Delete user
+- `GET /api/v1/users/me` - Get current user profile
+- `PUT /api/v1/users/me` - Update current user profile
 
 ### Leads (Sales and Admin access)
-- `GET /api/leads` - List leads
-- `POST /api/leads` - Create new lead
-- `GET /api/leads/:id` - Get specific lead
-- `PUT /api/leads/:id` - Update lead
-- `DELETE /api/leads/:id` - Delete lead
-- `POST /api/leads/:id/convert` - Convert lead to customer
+- `GET /api/v1/leads` - List leads
+- `POST /api/v1/leads` - Create new lead
+- `GET /api/v1/leads/:id` - Get specific lead
+- `PUT /api/v1/leads/:id` - Update lead
+- `DELETE /api/v1/leads/:id` - Delete lead
+- `POST /api/v1/leads/:id/convert` - Convert lead to customer
 
 ### Customers
-- `GET /api/customers` - List customers
-- `POST /api/customers` - Create new customer
-- `GET /api/customers/:id` - Get specific customer
-- `PUT /api/customers/:id` - Update customer
-- `DELETE /api/customers/:id` - Delete customer
+- `GET /api/v1/customers` - List customers
+- `POST /api/v1/customers` - Create new customer
+- `GET /api/v1/customers/:id` - Get specific customer
+- `PUT /api/v1/customers/:id` - Update customer
+- `DELETE /api/v1/customers/:id` - Delete customer
 
 ### Tickets (Support and Admin access)
-- `GET /api/tickets` - List tickets
-- `POST /api/tickets` - Create new ticket
-- `GET /api/tickets/:id` - Get specific ticket
-- `PUT /api/tickets/:id` - Update ticket
-- `DELETE /api/tickets/:id` - Delete ticket
-- `GET /api/tickets/my` - Get current user's tickets
+- `GET /api/v1/tickets` - List tickets
+- `POST /api/v1/tickets` - Create new ticket
+- `GET /api/v1/tickets/:id` - Get specific ticket
+- `PUT /api/v1/tickets/:id` - Update ticket
+- `DELETE /api/v1/tickets/:id` - Delete ticket
+- `GET /api/v1/tickets/my` - Get current user's tickets
 
 ### Tasks
-- `GET /api/tasks` - List tasks
-- `POST /api/tasks` - Create new task
-- `GET /api/tasks/:id` - Get specific task
-- `PUT /api/tasks/:id` - Update task
-- `DELETE /api/tasks/:id` - Delete task
-- `GET /api/tasks/my` - Get current user's tasks
+- `GET /api/v1/tasks` - List tasks
+- `POST /api/v1/tasks` - Create new task
+- `GET /api/v1/tasks/:id` - Get specific task
+- `PUT /api/v1/tasks/:id` - Update task
+- `DELETE /api/v1/tasks/:id` - Delete task
+- `GET /api/v1/tasks/my` - Get current user's tasks
 
 ### API Keys
-- `GET /api/api-keys` - List user's API keys
-- `POST /api/api-keys` - Create new API key
-- `DELETE /api/api-keys/:id` - Revoke API key
+- `GET /api/v1/api-keys` - List user's API keys
+- `POST /api/v1/api-keys` - Create new API key
+- `DELETE /api/v1/api-keys/:id` - Revoke API key
 
 ### Configuration (Admin only)
-- `GET /api/configurations` - List all configurations
-- `GET /api/configurations/ui` - Get UI-safe configurations
-- `GET /api/configurations/category/:category` - Get configurations by category
-- `GET /api/configurations/:key` - Get specific configuration
-- `PUT /api/configurations/:key` - Update configuration value
-- `POST /api/configurations/:key/reset` - Reset configuration to default
+- `GET /api/v1/configurations` - List all configurations
+- `GET /api/v1/configurations/ui` - Get UI-safe configurations
+- `GET /api/v1/configurations/category/:category` - Get configurations by category
+- `GET /api/v1/configurations/:key` - Get specific configuration
+- `PUT /api/v1/configurations/:key` - Update configuration value
+- `POST /api/v1/configurations/:key/reset` - Reset configuration to default
 
 ### Dashboard
-- `GET /api/dashboard/stats` - Get dashboard statistics (total leads, customers, open tickets, pending tasks, conversion rate)
+- `GET /api/v1/dashboard/stats` - Get dashboard statistics (total leads, customers, open tickets, pending tasks, conversion rate)
 
 ## Project Structure
 

--- a/doc/SETUP.md
+++ b/doc/SETUP.md
@@ -76,7 +76,7 @@ npm install
 cp .env.example .env
 
 # The default configuration should work:
-# VITE_API_BASE_URL=http://localhost:8080/api
+# VITE_API_BASE_URL=http://localhost:8080/api/v1
 ```
 
 ### 5. Run the Frontend
@@ -128,12 +128,12 @@ curl http://localhost:8080/health
 ### 3. Test API Directly
 ```bash
 # Login
-curl -X POST http://localhost:8080/api/auth/login \
+curl -X POST http://localhost:8080/api/v1/auth/login \
   -H "Content-Type: application/json" \
   -d '{"email":"admin@example.com","password":"yourpassword"}'
 
 # Use the returned token for authenticated requests
-curl http://localhost:8080/api/users/me \
+curl http://localhost:8080/api/v1/users/me \
   -H "Authorization: Bearer YOUR_TOKEN_HERE"
 ```
 
@@ -183,11 +183,11 @@ curl http://localhost:8080/api/users/me \
 
 The API endpoints follow RESTful conventions:
 
-- Auth: `/api/auth/*`
-- Users: `/api/users/*`
-- Leads: `/api/leads/*`
-- Customers: `/api/customers/*`
-- Tickets: `/api/tickets/*`
-- Tasks: `/api/tasks/*`
+- Auth: `/api/v1/auth/*`
+- Users: `/api/v1/users/*`
+- Leads: `/api/v1/leads/*`
+- Customers: `/api/v1/customers/*`
+- Tickets: `/api/v1/tickets/*`
+- Tasks: `/api/v1/tasks/*`
 
 All protected endpoints require an `Authorization: Bearer <token>` header.

--- a/gocrm-ui/README.md
+++ b/gocrm-ui/README.md
@@ -151,17 +151,17 @@ src/
 The frontend communicates with the GopherCRM backend through RESTful APIs:
 
 ### Authentication Endpoints
-- `POST /api/auth/login` - User authentication
-- `POST /api/auth/register` - User registration
+- `POST /api/v1/auth/login` - User authentication
+- `POST /api/v1/auth/register` - User registration
 
 ### Data Endpoints
-- Leads: `/api/leads/*`
-- Customers: `/api/customers/*`
-- Tickets: `/api/tickets/*`
-- Tasks: `/api/tasks/*`
-- Users: `/api/users/*`
-- Configurations: `/api/configurations/*`
-- Dashboard: `/api/dashboard/stats`
+- Leads: `/api/v1/leads/*`
+- Customers: `/api/v1/customers/*`
+- Tickets: `/api/v1/tickets/*`
+- Tasks: `/api/v1/tasks/*`
+- Users: `/api/v1/users/*`
+- Configurations: `/api/v1/configurations/*`
+- Dashboard: `/api/v1/dashboard/stats`
 
 ### Error Handling
 - Consistent error response format

--- a/gocrm-ui/e2e/pages/login.page.ts
+++ b/gocrm-ui/e2e/pages/login.page.ts
@@ -55,7 +55,7 @@ export class LoginPage {
 
   async submitAndWaitForResponse() {
     const responsePromise = this.page.waitForResponse(
-      response => response.url().includes('/api/auth/login')
+      response => response.url().includes('/api/v1/auth/login')
     );
     await this.submit();
     return await responsePromise;

--- a/gocrm-ui/e2e/tests/leads-sorting-search.spec.ts
+++ b/gocrm-ui/e2e/tests/leads-sorting-search.spec.ts
@@ -32,7 +32,7 @@ test.describe('Leads List - Sorting and Search', () => {
     await expect(createdHeader).toBeVisible();
 
     const responsePromise = page.waitForResponse(
-      response => response.url().includes('/api/leads') && response.request().method() === 'GET'
+      response => response.url().includes('/api/v1/leads') && response.request().method() === 'GET'
     );
     await createdHeader.click();
     const response = await responsePromise;
@@ -57,14 +57,14 @@ test.describe('Leads List - Sorting and Search', () => {
     const createdHeader = page.locator('th').filter({ hasText: 'Created' }).locator('span').first();
 
     let responsePromise = page.waitForResponse(
-      response => response.url().includes('/api/leads') && response.request().method() === 'GET'
+      response => response.url().includes('/api/v1/leads') && response.request().method() === 'GET'
     );
     await createdHeader.click();
     let response = await responsePromise;
     const firstUrl = response.request().url();
 
     responsePromise = page.waitForResponse(
-      response => response.url().includes('/api/leads') && response.request().method() === 'GET'
+      response => response.url().includes('/api/v1/leads') && response.request().method() === 'GET'
     );
     await createdHeader.click();
     response = await responsePromise;
@@ -85,7 +85,7 @@ test.describe('Leads List - Sorting and Search', () => {
     await leadsPage.tableRows.first().waitFor({ state: 'visible' });
 
     const responsePromise = page.waitForResponse(
-      response => response.url().includes('/api/leads') &&
+      response => response.url().includes('/api/v1/leads') &&
                   response.url().includes('search=') &&
                   response.request().method() === 'GET'
     );
@@ -113,7 +113,7 @@ test.describe('Leads List - Sorting and Search', () => {
     await leadsPage.tableRows.first().waitFor({ state: 'visible' });
 
     const responsePromise = page.waitForResponse(
-      response => response.url().includes('/api/leads') &&
+      response => response.url().includes('/api/v1/leads') &&
                   response.url().includes('search=') &&
                   response.request().method() === 'GET'
     );
@@ -141,7 +141,7 @@ test.describe('Leads List - Sorting and Search', () => {
     await leadsPage.tableRows.first().waitFor({ state: 'visible' });
 
     let responsePromise = page.waitForResponse(
-      response => response.url().includes('/api/leads') &&
+      response => response.url().includes('/api/v1/leads') &&
                   response.url().includes('search=') &&
                   response.request().method() === 'GET'
     );
@@ -153,7 +153,7 @@ test.describe('Leads List - Sorting and Search', () => {
     const createdHeader = page.locator('th').filter({ hasText: 'Created' }).locator('span').first();
 
     responsePromise = page.waitForResponse(
-      response => response.url().includes('/api/leads') && response.request().method() === 'GET'
+      response => response.url().includes('/api/v1/leads') && response.request().method() === 'GET'
     );
     await createdHeader.click();
     const response = await responsePromise;
@@ -174,7 +174,7 @@ test.describe('Leads List - Sorting and Search', () => {
     const initialCount = await leadsPage.tableRows.count();
 
     let responsePromise = page.waitForResponse(
-      response => response.url().includes('/api/leads') && response.request().method() === 'GET'
+      response => response.url().includes('/api/v1/leads') && response.request().method() === 'GET'
     );
     await leadsPage.searchInput.fill('anders.t@conversio.dk');
     await responsePromise;
@@ -184,7 +184,7 @@ test.describe('Leads List - Sorting and Search', () => {
     const filteredCount = await leadsPage.tableRows.count();
 
     responsePromise = page.waitForResponse(
-      response => response.url().includes('/api/leads') && response.request().method() === 'GET'
+      response => response.url().includes('/api/v1/leads') && response.request().method() === 'GET'
     );
     await leadsPage.searchInput.clear();
     await responsePromise;
@@ -203,7 +203,7 @@ test.describe('Leads List - Sorting and Search', () => {
     await leadsPage.tableRows.first().waitFor({ state: 'visible' });
 
     const responsePromise = page.waitForResponse(
-      response => response.url().includes('/api/leads') &&
+      response => response.url().includes('/api/v1/leads') &&
                   response.url().includes('search=') &&
                   response.request().method() === 'GET'
     );

--- a/gocrm-ui/src/api/client.ts
+++ b/gocrm-ui/src/api/client.ts
@@ -2,7 +2,7 @@ import axios, { AxiosError } from 'axios';
 import type { AxiosInstance, InternalAxiosRequestConfig } from 'axios';
 import type { APIError } from '@/types';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api/v1';
 const API_TIMEOUT = Number(import.meta.env.VITE_API_TIMEOUT) || 30000;
 
 export const TOKEN_KEY = 'gophercrm_token';

--- a/tests/configuration_integration_test.go
+++ b/tests/configuration_integration_test.go
@@ -138,7 +138,7 @@ func (suite *ConfigurationIntegrationTestSuite) TearDownSuite() {
 
 func (suite *ConfigurationIntegrationTestSuite) TestGetUIConfigurations() {
 	// Test with admin user
-	req, _ := http.NewRequest("GET", "/api/configurations/ui", nil)
+	req, _ := http.NewRequest("GET", "/api/v1/configurations/ui", nil)
 	req.Header.Set("Authorization", "Bearer "+suite.adminToken)
 	
 	w := httptest.NewRecorder()
@@ -155,7 +155,7 @@ func (suite *ConfigurationIntegrationTestSuite) TestGetUIConfigurations() {
 	suite.Greater(len(configurations), 0)
 	
 	// Test with regular user (should also work)
-	req, _ = http.NewRequest("GET", "/api/configurations/ui", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/configurations/ui", nil)
 	req.Header.Set("Authorization", "Bearer "+suite.regularUserToken)
 	
 	w = httptest.NewRecorder()
@@ -166,7 +166,7 @@ func (suite *ConfigurationIntegrationTestSuite) TestGetUIConfigurations() {
 
 func (suite *ConfigurationIntegrationTestSuite) TestGetAllConfigurations_AdminOnly() {
 	// Test with admin user - should work
-	req, _ := http.NewRequest("GET", "/api/configurations", nil)
+	req, _ := http.NewRequest("GET", "/api/v1/configurations", nil)
 	req.Header.Set("Authorization", "Bearer "+suite.adminToken)
 	
 	w := httptest.NewRecorder()
@@ -183,7 +183,7 @@ func (suite *ConfigurationIntegrationTestSuite) TestGetAllConfigurations_AdminOn
 	suite.Greater(len(configurations), 0)
 	
 	// Test with regular user - should fail
-	req, _ = http.NewRequest("GET", "/api/configurations", nil)
+	req, _ = http.NewRequest("GET", "/api/v1/configurations", nil)
 	req.Header.Set("Authorization", "Bearer "+suite.regularUserToken)
 	
 	w = httptest.NewRecorder()
@@ -194,7 +194,7 @@ func (suite *ConfigurationIntegrationTestSuite) TestGetAllConfigurations_AdminOn
 
 func (suite *ConfigurationIntegrationTestSuite) TestGetConfigurationByCategory() {
 	// Test getting UI configurations
-	req, _ := http.NewRequest("GET", "/api/configurations/category/ui", nil)
+	req, _ := http.NewRequest("GET", "/api/v1/configurations/category/ui", nil)
 	req.Header.Set("Authorization", "Bearer "+suite.adminToken)
 	
 	w := httptest.NewRecorder()
@@ -218,7 +218,7 @@ func (suite *ConfigurationIntegrationTestSuite) TestGetConfigurationByCategory()
 
 func (suite *ConfigurationIntegrationTestSuite) TestGetConfigurationByKey() {
 	// Test getting specific configuration
-	req, _ := http.NewRequest("GET", "/api/configurations/general.company_name", nil)
+	req, _ := http.NewRequest("GET", "/api/v1/configurations/general.company_name", nil)
 	req.Header.Set("Authorization", "Bearer "+suite.adminToken)
 	
 	w := httptest.NewRecorder()
@@ -242,7 +242,7 @@ func (suite *ConfigurationIntegrationTestSuite) TestSetConfiguration() {
 	}
 	
 	bodyBytes, _ := json.Marshal(requestBody)
-	req, _ := http.NewRequest("PUT", "/api/configurations/general.company_name", bytes.NewBuffer(bodyBytes))
+	req, _ := http.NewRequest("PUT", "/api/v1/configurations/general.company_name", bytes.NewBuffer(bodyBytes))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+suite.adminToken)
 	
@@ -271,7 +271,7 @@ func (suite *ConfigurationIntegrationTestSuite) TestSetConfiguration_InvalidValu
 	}
 	
 	bodyBytes, _ := json.Marshal(requestBody)
-	req, _ := http.NewRequest("PUT", "/api/configurations/security.session_timeout_hours", bytes.NewBuffer(bodyBytes))
+	req, _ := http.NewRequest("PUT", "/api/v1/configurations/security.session_timeout_hours", bytes.NewBuffer(bodyBytes))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+suite.adminToken)
 	
@@ -325,7 +325,7 @@ func (suite *ConfigurationIntegrationTestSuite) TestSetConfiguration_ReadOnly() 
 	}
 	
 	bodyBytes, _ := json.Marshal(requestBody)
-	req, _ := http.NewRequest("PUT", fmt.Sprintf("/api/configurations/%s", readOnlyKey), bytes.NewBuffer(bodyBytes))
+	req, _ := http.NewRequest("PUT", fmt.Sprintf("/api/v1/configurations/%s", readOnlyKey), bytes.NewBuffer(bodyBytes))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+suite.adminToken)
 	
@@ -353,7 +353,7 @@ func (suite *ConfigurationIntegrationTestSuite) TestResetConfiguration() {
 	assert.Equal(suite.T(), "Custom Company", value)
 	
 	// Reset to default
-	req, _ := http.NewRequest("POST", "/api/configurations/general.company_name/reset", nil)
+	req, _ := http.NewRequest("POST", "/api/v1/configurations/general.company_name/reset", nil)
 	req.Header.Set("Authorization", "Bearer "+suite.adminToken)
 	
 	w := httptest.NewRecorder()
@@ -374,7 +374,7 @@ func (suite *ConfigurationIntegrationTestSuite) TestBooleanConfiguration() {
 	}
 	
 	bodyBytes, _ := json.Marshal(requestBody)
-	req, _ := http.NewRequest("PUT", "/api/configurations/leads.conversion.require_notes", bytes.NewBuffer(bodyBytes))
+	req, _ := http.NewRequest("PUT", "/api/v1/configurations/leads.conversion.require_notes", bytes.NewBuffer(bodyBytes))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+suite.adminToken)
 	
@@ -396,7 +396,7 @@ func (suite *ConfigurationIntegrationTestSuite) TestArrayConfiguration() {
 	}
 
 	bodyBytes, _ := json.Marshal(requestBody)
-	req, _ := http.NewRequest("PUT", "/api/configurations/leads.conversion.allowed_statuses", bytes.NewBuffer(bodyBytes))
+	req, _ := http.NewRequest("PUT", "/api/v1/configurations/leads.conversion.allowed_statuses", bytes.NewBuffer(bodyBytes))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+suite.adminToken)
 
@@ -435,7 +435,7 @@ func (suite *ConfigurationIntegrationTestSuite) TestServiceSpecificMethods() {
 
 func (suite *ConfigurationIntegrationTestSuite) TestConfigurationNotFound() {
 	// Test getting non-existent configuration
-	req, _ := http.NewRequest("GET", "/api/configurations/non.existent.key", nil)
+	req, _ := http.NewRequest("GET", "/api/v1/configurations/non.existent.key", nil)
 	req.Header.Set("Authorization", "Bearer "+suite.adminToken)
 	
 	w := httptest.NewRecorder()
@@ -446,7 +446,7 @@ func (suite *ConfigurationIntegrationTestSuite) TestConfigurationNotFound() {
 
 func (suite *ConfigurationIntegrationTestSuite) TestUnauthorizedAccess() {
 	// Test without token
-	req, _ := http.NewRequest("GET", "/api/configurations", nil)
+	req, _ := http.NewRequest("GET", "/api/v1/configurations", nil)
 	
 	w := httptest.NewRecorder()
 	suite.router.ServeHTTP(w, req)


### PR DESCRIPTION
## Summary

Fixed critical route inconsistency where frontend defaulted to /api while backend used /api/v1. This caused "Invalid email or password" errors when users tried to log in without manually configuring .env.local.

## Root Cause

- Backend: Configured with API_PREFIX=/api/v1 (default)
- Frontend: Default fallback URL was http://localhost:8080/api (missing /v1)

When no .env.local file existed, the frontend would call /api/auth/login but the backend only served /api/v1/auth/login, resulting in 404 errors.

## Changes

- gocrm-ui/src/api/client.ts: Updated default API URL from /api to /api/v1
- README.md: Updated all API endpoint docs from /api/* to /api/v1/*
- doc/SETUP.md: Fixed API URL examples and endpoint documentation
- gocrm-ui/README.md: Fixed API endpoint documentation
- gocrm-ui/e2e/pages/login.page.ts: Fixed login endpoint path
- gocrm-ui/e2e/tests/leads-sorting-search.spec.ts: Fixed all leads endpoint paths
- tests/configuration_integration_test.go: Fixed all endpoint paths

## Verification

- Backend starts correctly with /api/v1 routes
- Auth integration tests pass
- API login works: POST /api/v1/auth/login

## Testing

1. Clone fresh repo
2. Start backend: make run
3. Start frontend: cd gocrm-ui && npm run dev
4. Login works without any .env.local file
